### PR TITLE
topic/entity#23 null entity handle

### DIFF
--- a/src/apps/entity_tests/HandleEntity_tests.cpp
+++ b/src/apps/entity_tests/HandleEntity_tests.cpp
@@ -65,6 +65,7 @@ SCENARIO("Handles provide a phase-less view access to Entities.")
     }
 }
 
+
 SCENARIO("Handles are comparable")
 {
     GIVEN("An entity Manager with two handle on the same entity")
@@ -126,6 +127,25 @@ SCENARIO("Handles allow to test the validity of the underlying Entity.")
                     }
                 }
             }
+        }
+    }
+}
+
+
+SCENARIO("Default constructed handles.")
+{
+    GIVEN("A default constructed Entity handle")
+    {
+        Handle<Entity> hDefault;
+
+        THEN("The handle is not valid.")
+        {
+            CHECK_FALSE(hDefault.isValid());
+        }
+
+        THEN("It cannot be used to obtain en Entity.")
+        {
+            CHECK_FALSE(hDefault.get().has_value());
         }
     }
 }

--- a/src/libs/entity/entity/ArchetypeStore.h
+++ b/src/libs/entity/entity/ArchetypeStore.h
@@ -47,6 +47,8 @@ private:
     };
 
     inline static const TypeSet gEmptyTypeSet{};
+    // Has to be zero (first index in the vector)
+    static constexpr HandleKey<Archetype> gEmptyTypeSetArchetypeHandle{0};
 
     // Initially, we stored the archetype by value in the vector
     // Yet on reallocation, this would invalidate all reference to the archetype
@@ -55,7 +57,7 @@ private:
     std::map<TypeSet, HandleKey<Archetype>> mTypeSetToArchetype{
         {
             gEmptyTypeSet,
-            {}
+            gEmptyTypeSetArchetypeHandle, 
         }
     };
 };
@@ -64,8 +66,8 @@ private:
 inline std::pair<Archetype &, HandleKey<Archetype>> ArchetypeStore::getEmptyArchetype()
 {
     return {
-        *mHandleToArchetype[0],
-        {},
+        *mHandleToArchetype[gEmptyTypeSetArchetypeHandle],
+        gEmptyTypeSetArchetypeHandle,
     };
 }
 

--- a/src/libs/entity/entity/Entity.cpp
+++ b/src/libs/entity/entity/Entity.cpp
@@ -32,6 +32,13 @@ Archetype & Handle<Archetype>::get()
 }
 
 
+Handle<Entity>::Handle() :
+    Handle{
+        HandleKey<Entity>{HandleKey<Entity>::gInvalidKey},
+        EntityManager::getEmptyHandleEntityManager()}
+{}
+
+
 bool Handle<Entity>::isValid() const
 {
     EntityRecord current = record();

--- a/src/libs/entity/entity/Entity.h
+++ b/src/libs/entity/entity/Entity.h
@@ -167,6 +167,13 @@ class Handle<Entity>
     friend class detail::QueryBackend;
 
 public:
+    /// \brief Construct a default Handle, which is not valid.
+    /// \details This constructor assigns the invalid HandleKey and a
+    /// static (private) EntityManager to the handle. 
+    /// This EntityManager has an "invalid record" associated to the invalid HandleKey.
+    /// This approach allows to not make a special case for the default constructed handle.
+    Handle();
+
     /// \brief Checks whether the handle is valid, currently pointing to an Entity.
     // TODO not sure it should exist as a standalone, as it duplicates some logic from get()
     bool isValid() const;

--- a/src/libs/entity/entity/EntityManager.h
+++ b/src/libs/entity/entity/EntityManager.h
@@ -80,7 +80,8 @@ class EntityManager
         HandleKey<Entity> getAvailableHandle();
 
         // TODO Refactor the Handle<Entity> related members into a coherent separate class.
-        HandleKey<Entity> mNextHandle;
+        HandleKey<Entity> mNextHandle{0}; // Initially, the first handle is the next handle.
+
         std::map<HandleKey<Entity>, EntityRecord> mHandleMap;
         std::deque<HandleKey<Entity>> mFreedHandles;
 

--- a/src/libs/entity/entity/EntityManager.h
+++ b/src/libs/entity/entity/EntityManager.h
@@ -71,6 +71,8 @@ class EntityManager
         std::vector<detail::QueryBackendBase *>
         getExtraQueryBackends(const Archetype & aCompared, const Archetype & aReference) const;
 
+        void insertInvalidHandleKey();
+
     private:
         template <class F_maker>
         HandleKey<Archetype> makeArchetypeIfAbsent(const TypeSet & aTargetTypeSet,
@@ -145,6 +147,10 @@ private:
     std::vector<detail::QueryBackendBase *>
     getExtraQueryBackends(const Archetype & aCompared, const Archetype & aReference) const
     { return mState->getExtraQueryBackends(aCompared, aReference); }
+
+    // Only used by the default constructor of Handle<Entity>.
+    // See Handle<Entity>::Handle() for context.
+    static EntityManager & getEmptyHandleEntityManager();
 
     std::unique_ptr<InternalState> mState = std::make_unique<InternalState>();
 };

--- a/src/libs/entity/entity/HandleKey.h
+++ b/src/libs/entity/entity/HandleKey.h
@@ -12,24 +12,26 @@ template <class>
 class HandleKey
 {
 public:
-    HandleKey() = default;
+    using Underlying_t = std::size_t;
 
-    HandleKey(std::size_t aIndex) :
+    HandleKey() = delete;
+
+    constexpr HandleKey(Underlying_t aIndex) :
         mIndex{aIndex}
     {}
 
-    bool operator==(const HandleKey & aRhs) const = default;
+    constexpr bool operator==(const HandleKey & aRhs) const = default;
 
-    /*implicit: for array access*/ operator std::size_t () const
+    /*implicit: for array access*/ constexpr operator Underlying_t () const
     { return mIndex; }
 
-    HandleKey operator++(int /*postfix*/)
+    constexpr HandleKey operator++(int /*postfix*/)
     {
         return HandleKey{mIndex++};
     }
 
 private:
-    std::size_t mIndex{0};
+    Underlying_t mIndex;
 };
 
 

--- a/src/libs/entity/entity/HandleKey.h
+++ b/src/libs/entity/entity/HandleKey.h
@@ -14,6 +14,8 @@ class HandleKey
 public:
     using Underlying_t = std::size_t;
 
+    static constexpr auto gInvalidKey = std::numeric_limits<Underlying_t>::max();
+
     HandleKey() = delete;
 
     constexpr HandleKey(Underlying_t aIndex) :


### PR DESCRIPTION
closes #23.
- Use named constants for empty Archetype initialization.
- Delete HandleKey default ctor, make the class constexpr.
- Implement default ctor for an invalid Handle<Entity>.
