### PR TITLE
topic/entity#25 entity handle generation

### DIFF
--- a/src/apps/entity_tests/HandleEntity_tests.cpp
+++ b/src/apps/entity_tests/HandleEntity_tests.cpp
@@ -149,3 +149,40 @@ SCENARIO("Default constructed handles.")
         }
     }
 }
+
+
+SCENARIO("Handle re-use.")
+{
+    GIVEN("An entity manager with an entity.")
+    {
+        EntityManager world;
+        Handle<Entity> h1 = world.addEntity();
+
+        WHEN("The Entity is obtained and erased.")
+        {
+            {
+                Phase scoped;
+                std::optional<Entity> o1 = h1.get(scoped);
+                o1->erase();
+            }
+
+            // Sanity check
+            REQUIRE_FALSE(h1.isValid());
+
+            WHEN("Another entity is added.") 
+            {
+                Handle<Entity> h2 = world.addEntity();
+
+                // Note: this is not a functional requirement of the library,
+                // but the following CHECKs does not validate anything if this assertion does not hold true.
+                REQUIRE(h2.id() == h1.id());
+
+                THEN("The first handle is still invalid.")
+                {
+                    CHECK_FALSE(h1.isValid());
+                    CHECK(h2.isValid());
+                }
+            }
+        }
+    }
+}

--- a/src/libs/entity/entity/ArchetypeStore.h
+++ b/src/libs/entity/entity/ArchetypeStore.h
@@ -50,12 +50,13 @@ private:
 
     inline static const TypeSet gEmptyTypeSet{};
     // Has to be zero (first index in the vector)
-    static constexpr HandleKey<Archetype> gEmptyTypeSetArchetypeHandle{0};
+    static constexpr HandleKey<Archetype> gEmptyTypeSetArchetypeHandle{HandleKey<Archetype>::MakeFirst()};
 
     // Initially, we stored the archetype by value in the vector
     // Yet on reallocation, this would invalidate all reference to the archetype
     // (notably, to its vector of handles in Query::each())
     std::vector<std::unique_ptr<Archetype>> mHandleToArchetype{getInitialVector()};
+    // TODO It is probably not useful to use an HandleKey here, a simple index could be better.
     std::map<TypeSet, HandleKey<Archetype>> mTypeSetToArchetype{
         {
             gEmptyTypeSet,
@@ -106,7 +107,7 @@ std::pair<HandleKey<Archetype>, bool> ArchetypeStore::makeIfAbsent(const TypeSet
         mHandleToArchetype.push_back(aMakeCallback());
         HandleKey<Archetype> inserted = mTypeSetToArchetype.emplace(
             aTargetTypeSet,
-            HandleKey<Archetype>{insertedPosition})
+            HandleKey<Archetype>::MakeIndex(insertedPosition))
             .first->second;
         return {inserted, true};
     }

--- a/src/libs/entity/entity/ArchetypeStore.h
+++ b/src/libs/entity/entity/ArchetypeStore.h
@@ -34,6 +34,8 @@ public:
     auto size() const
     { return mHandleToArchetype.size(); }
 
+    /// \return The HandleKey to the archetype matching `aTargetTypeSet`,
+    /// and true if it was inserted, false if it was already present.
     template <class F_maker>
     std::pair<HandleKey<Archetype>, bool> makeIfAbsent(const TypeSet & aTargetTypeSet,
                                                        F_maker aMakeCallback);

--- a/src/libs/entity/entity/Component.h
+++ b/src/libs/entity/entity/Component.h
@@ -12,9 +12,6 @@ namespace ent {
 
 
 using EntityIndex = std::size_t;
-// TODO to be removed, when the validity of an handle is to be tested based on its generation.
-constexpr EntityIndex gInvalidIndex = std::numeric_limits<EntityIndex>::max();
-
 
 using ComponentId = std::type_index;
 

--- a/src/libs/entity/entity/Entity.cpp
+++ b/src/libs/entity/entity/Entity.cpp
@@ -41,20 +41,19 @@ Handle<Entity>::Handle() :
 
 bool Handle<Entity>::isValid() const
 {
-    EntityRecord current = record();
-    return current.mIndex != gInvalidIndex;
+    // This will test if the generation is the same (it would be a logical error if the index was not).
+    // Compare against mKey (which inlcudes the generation), not ::id()
+    return mManager->keyForIndex(mKey) == mKey;
 }
 
 
 std::optional<Entity_view> Handle<Entity>::get() const
 {
-    EntityRecord current = record();
-
     // TODO Potential optimisation: is it wise to to the check here?
     // Knowing that the client has to check.
     // record() already return a nullptr archetype for invalid entities,
     // which could directly be checked by the client.
-    if(current.mIndex != gInvalidIndex)
+    if(isValid())
     {
         return Entity_view{
             reference(),
@@ -69,13 +68,11 @@ std::optional<Entity_view> Handle<Entity>::get() const
 
 std::optional<Entity> Handle<Entity>::get(Phase & aPhase)
 {
-    EntityRecord current = record();
-
     // TODO Potential optimisation: is it wise to to the check here?
     // Knowing that the client has to check.
     // record() already return a nullptr archetype for invalid entities,
     // which could directly be checked by the client.
-    if(current.mIndex != gInvalidIndex)
+    if(isValid())
     {
         return Entity{
             reference(),

--- a/src/libs/entity/entity/Entity.cpp
+++ b/src/libs/entity/entity/Entity.cpp
@@ -34,7 +34,7 @@ Archetype & Handle<Archetype>::get()
 
 Handle<Entity>::Handle() :
     Handle{
-        HandleKey<Entity>::MakeInvalid(),
+        HandleKey<Entity>::MakeLatest(),
         EntityManager::getEmptyHandleEntityManager()}
 {}
 

--- a/src/libs/entity/entity/Entity.cpp
+++ b/src/libs/entity/entity/Entity.cpp
@@ -34,7 +34,7 @@ Archetype & Handle<Archetype>::get()
 
 Handle<Entity>::Handle() :
     Handle{
-        HandleKey<Entity>{HandleKey<Entity>::gInvalidKey},
+        HandleKey<Entity>::MakeInvalid(),
         EntityManager::getEmptyHandleEntityManager()}
 {}
 

--- a/src/libs/entity/entity/Entity.h
+++ b/src/libs/entity/entity/Entity.h
@@ -37,7 +37,7 @@ public:
     //}
 
 private:
-    Handle(std::size_t aKey, EntityManager & aManager) :
+    Handle(HandleKey<Archetype> aKey, EntityManager & aManager) :
         mKey{aKey},
         mManager{&aManager}
     {}
@@ -189,6 +189,7 @@ public:
         return aLhs.mKey == aRhs.mKey;
     }
 
+    /// \attention Removes the generation, only returning the index part of the HandleKey.
     EntityIndex id() const
     {
         return mKey;

--- a/src/libs/entity/entity/EntityManager.cpp
+++ b/src/libs/entity/entity/EntityManager.cpp
@@ -46,14 +46,14 @@ EntityRecord & EntityManager::InternalState::record(HandleKey<Entity> aKey)
 
 Archetype & EntityManager::InternalState::archetype(HandleKey<Archetype> aHandle)
 {
-    assert(aHandle != HandleKey<Archetype>{HandleKey<Archetype>::gInvalidKey}); // At the moment, there is not Archetype for the invalid key.
+    assert(aHandle != HandleKey<Archetype>::MakeInvalid()); // At the moment, there is not Archetype for the invalid key.
     return mArchetypes.get(aHandle);
 }
 
 
 void EntityManager::InternalState::freeHandle(HandleKey<Entity> aKey)
 { 
-    assert(aKey != HandleKey<Entity>{HandleKey<Entity>::gInvalidKey});
+    assert(aKey != HandleKey<Entity>::MakeInvalid());
     record(aKey).mIndex = gInvalidIndex;
     mFreedHandles.push_back(std::move(aKey));
 }
@@ -110,8 +110,8 @@ HandleKey<Entity> EntityManager::InternalState::getAvailableHandle()
 void EntityManager::InternalState::insertInvalidHandleKey()
 {
     mHandleMap.emplace(
-        HandleKey<Entity>{HandleKey<Entity>::gInvalidKey},
-        EntityRecord{HandleKey<Archetype>::gInvalidKey, gInvalidIndex}
+        HandleKey<Entity>::MakeInvalid(),
+        EntityRecord{HandleKey<Archetype>::MakeInvalid(), gInvalidIndex}
     );
 }
 

--- a/src/libs/entity/entity/EntityManager.h
+++ b/src/libs/entity/entity/EntityManager.h
@@ -82,7 +82,7 @@ class EntityManager
         HandleKey<Entity> getAvailableHandle();
 
         // TODO Refactor the Handle<Entity> related members into a coherent separate class.
-        HandleKey<Entity> mNextHandle{0}; // Initially, the first handle is the next handle.
+        HandleKey<Entity> mNextHandle{HandleKey<Entity>::MakeFirst()}; // Initially, the first handle is the next handle.
 
         std::map<HandleKey<Entity>, EntityRecord> mHandleMap;
         std::deque<HandleKey<Entity>> mFreedHandles;
@@ -299,18 +299,18 @@ void Handle<Entity>::remove()
 inline Handle<Entity> EntityManager::InternalState::addEntity(EntityManager & aManager)
 {
     // We know the empty archetype is first in the vector
-    std::pair<Archetype &, HandleKey<Archetype>> empty =  mArchetypes.getEmptyArchetype();
+    std::pair<Archetype &, HandleKey<Archetype>> emptyArchetype =  mArchetypes.getEmptyArchetype();
 
     HandleKey<Entity> key = getAvailableHandle();
     mHandleMap.insert_or_assign(
         key,
         EntityRecord{
-            empty.second,
-            empty.first.countEntities(),
+            emptyArchetype.second,
+            emptyArchetype.first.countEntities(),
         });
 
     // Has to be done after taking the entity count as index, for the new EntityRecord.
-    empty.first.pushKey(key);
+    emptyArchetype.first.pushKey(key);
 
     return Handle<Entity>{key, aManager};
 }

--- a/src/libs/entity/entity/EntityManager.h
+++ b/src/libs/entity/entity/EntityManager.h
@@ -52,6 +52,13 @@ class EntityManager
         HandleKey<Archetype> restrictArchetype(const Archetype & aArchetype);
 
         EntityRecord & record(HandleKey<Entity> aKey);
+
+        /// \brief Return the complete HandleKey currently associated with the index subpart of `aKey`.
+        /// \details mHandleMap is only comparing the index part of the HandleKey, which means
+        /// this function will return an HandleKey with the same index, but not necessarily the same generation.
+        /// This is usefull to test an Handle validity.
+        const HandleKey<Entity> & keyForIndex(HandleKey<Entity> aKey);
+
         Archetype & archetype(HandleKey<Archetype> aHandle);
 
         void freeHandle(HandleKey<Entity> aKey);
@@ -84,7 +91,10 @@ class EntityManager
         // TODO Refactor the Handle<Entity> related members into a coherent separate class.
         HandleKey<Entity> mNextHandle{HandleKey<Entity>::MakeFirst()}; // Initially, the first handle is the next handle.
 
-        std::map<HandleKey<Entity>, EntityRecord> mHandleMap;
+        // Note: Uses a custom comparison, only testing the index part of the HandleKey (not the generation).
+        // This is to be consistent with the fact that different generations of the same index should be placed 
+        // at the same key position from the map perspective.
+        std::map<HandleKey<Entity>, EntityRecord, HandleKey<Entity>::LessIndex> mHandleMap;
         std::deque<HandleKey<Entity>> mFreedHandles;
 
         // This must appear BEFORE the archetypes, so QueryBackends are destructed AFTER Archetypes:
@@ -126,6 +136,9 @@ private:
 
     EntityRecord & record(HandleKey<Entity> aKey)
     { return mState->record(aKey); }
+
+    const HandleKey<Entity> & keyForIndex(HandleKey<Entity> aKey)
+    { return mState->keyForIndex(aKey); }
 
     Archetype & archetype(HandleKey<Archetype> aHandle)
     { return mState->archetype(aHandle); }

--- a/src/libs/entity/entity/HandleKey.h
+++ b/src/libs/entity/entity/HandleKey.h
@@ -26,7 +26,7 @@ private:
     // Note that the functionality of "Invalid Handle<Entity>" does not need a special HandleKey value
     // since it simply use the value to get an invalid record in a dedicated EntityManager (and it could be associated to a normal key).
     // But this might make debugging easier to have a special value.
-    static constexpr auto gInvalidKey = std::numeric_limits<Underlying_t>::max();
+    static constexpr auto gMaxValue = std::numeric_limits<Underlying_t>::max();
 
     // The N high order bits are used for the generation.
     static constexpr auto gGenerationBits = 24;
@@ -43,9 +43,11 @@ public:
         return HandleKey{0};
     }
 
-    static constexpr HandleKey MakeInvalid()
+    /// \brief This HandleKey is not invalid, but has all bits to 1.
+    /// This is intended for the invalid default constructed Handle, to be easily spotted in debug.
+    static constexpr HandleKey MakeLatest()
     {
-        return HandleKey{gInvalidKey};
+        return HandleKey{gMaxValue};
     }
 
     /// \brief Make the handle key with provided index, and first generation.

--- a/src/libs/entity/entity/HandleKey.h
+++ b/src/libs/entity/entity/HandleKey.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 
 
@@ -7,43 +8,105 @@ namespace ad {
 namespace ent {
 
 
-/// \note The class argument is intended to have distinct types depending of what is handled.
+/// \note The class template type argument is intended to have distinct types depending of what is handled.
+/// \brief Abstraction for the key value of an Handle, it uses bit manipulation to store several logic values in an integer. 
+/// Currently stores an index (to access the entity in a registry),
+/// and a generation (to ensure the pointed Entity matches the HandleKey, and is not a reuse of the same index).
+/// \see: https://ajmmertens.medium.com/doing-a-lot-with-a-little-ecs-identifiers-25a72bd2647
 template <class>
 class HandleKey
 {
 public:
+    // TODO use sized type
     using Underlying_t = std::size_t;
+
+private:
+    static_assert(sizeof(Underlying_t) == 8, "The underlying type must be 64 bits.");
 
     // Note that the functionality of "Invalid Handle<Entity>" does not need a special HandleKey value
     // since it simply use the value to get an invalid record in a dedicated EntityManager (and it could be associated to a normal key).
     // But this might make debugging easier to have a special value.
     static constexpr auto gInvalidKey = std::numeric_limits<Underlying_t>::max();
 
+    // The N high order bits are used for the generation.
+    static constexpr auto gGenerationBits = 24;
+    static constexpr auto gGenerationShift = (64 - gGenerationBits);
+
+    static constexpr Underlying_t gGenerationMask = std::numeric_limits<Underlying_t>::max() << gGenerationShift;
+    static constexpr Underlying_t gIndexMask = ~gGenerationMask;
+
+public:
     HandleKey() = delete;
 
-    constexpr HandleKey(Underlying_t aIndex) :
-        mIndex{aIndex}
-    {}
-    static constexpr HandleKey MakeInvalid()
+    static constexpr HandleKey MakeFirst()
     {
-        HandleKey invalid{0};
-        invalid.mIndex = gInvalidKey;
-        return invalid;
+        return HandleKey{0};
     }
 
+    static constexpr HandleKey MakeInvalid()
+    {
+        return HandleKey{gInvalidKey};
+    }
+
+    /// \brief Make the handle key with provided index, and first generation.
+    static constexpr HandleKey MakeIndex(Underlying_t aIndex)
+    {
+        assert((aIndex & gGenerationMask) == 0);
+        return HandleKey{aIndex & gIndexMask};
+    }
 
     constexpr bool operator==(const HandleKey & aRhs) const = default;
 
+    /// \brief Return the index value (discarding the generation).
     /*implicit: for array access*/ constexpr operator Underlying_t () const
-    { return mIndex; }
+    { return mGenerationAndIndex & gIndexMask; }
 
+    /// \brief Increment the index value (keeping the same generation).
     constexpr HandleKey operator++(int /*postfix*/)
     {
-        return HandleKey{mIndex++};
+        // Assign the increment index part 
+        // (mask ensures that wrapping over the index does not bleed on generation)
+        HandleKey incremented{mGenerationAndIndex++ & gIndexMask};
+        // Copy over the generation
+        incremented.mGenerationAndIndex |= mGenerationAndIndex & gGenerationMask;
+        return incremented;
     }
 
+    // TODO this being const is a massive code smell.
+    // Adressing it require to either store the generation in the EntityRecord (which is non-const in the map, contrary to the key)
+    // or replacing the map altogether, which is probably the way to go (e.g. SparseSet).
+    /// \brief Increment the generation.
+    constexpr const HandleKey & advanceGeneration() const
+    {
+        auto newGeneration = ((mGenerationAndIndex >> gGenerationShift) + 1) << gGenerationShift;
+        mGenerationAndIndex = newGeneration | (mGenerationAndIndex & gIndexMask);
+        return *this;
+    }
+
+    /// \brief Return true if the HandleKey generation is the last generation 
+    /// Advancing the generation after the last wraps around,
+    /// with an associated risk of collision.
+    constexpr bool isLastGeneration() const
+    {
+        return (mGenerationAndIndex >> gGenerationShift) == gGenerationMask;
+    }
+
+    /// \brief Compare the index only, disregard generation.
+    struct LessIndex
+    {
+        bool operator()(const HandleKey & aLhs, const HandleKey & aRhs) const
+        {
+            return (Underlying_t)aLhs < (Underlying_t)aRhs;
+        }
+    };
+
 private:
-    Underlying_t mIndex;
+    constexpr HandleKey(Underlying_t aGenerationAndIndex) :
+        mGenerationAndIndex{aGenerationAndIndex}
+    {}
+
+    // We need to advance generation on HandleKey<Entity> used as map key (so only returned as const ref)
+    mutable Underlying_t mGenerationAndIndex;
 };
 
 

--- a/src/libs/entity/entity/HandleKey.h
+++ b/src/libs/entity/entity/HandleKey.h
@@ -14,6 +14,9 @@ class HandleKey
 public:
     using Underlying_t = std::size_t;
 
+    // Note that the functionality of "Invalid Handle<Entity>" does not need a special HandleKey value
+    // since it simply use the value to get an invalid record in a dedicated EntityManager (and it could be associated to a normal key).
+    // But this might make debugging easier to have a special value.
     static constexpr auto gInvalidKey = std::numeric_limits<Underlying_t>::max();
 
     HandleKey() = delete;
@@ -21,6 +24,13 @@ public:
     constexpr HandleKey(Underlying_t aIndex) :
         mIndex{aIndex}
     {}
+    static constexpr HandleKey MakeInvalid()
+    {
+        HandleKey invalid{0};
+        invalid.mIndex = gInvalidKey;
+        return invalid;
+    }
+
 
     constexpr bool operator==(const HandleKey & aRhs) const = default;
 

--- a/src/libs/entity/entity/Wrap.h
+++ b/src/libs/entity/entity/Wrap.h
@@ -71,8 +71,6 @@ private:
     T_stored & get() const
     {
         const EntityRecord & record = mWrapped.record();
-        assert(record.mIndex != gInvalidIndex); // since we reverted the exclusivitiy between Query and Wrap
-
         // Wrap stores a single component on the entity, so the storage index is 0.
         Storage<T_stored> & storage = mWrapped.archetype().getStorage(StorageIndex<T_stored>{0});
         // We do not check the index validity, no other code should be able to remove the entity.


### PR DESCRIPTION
closes #25.
- Add explicit HandleKey::MakeInvalid().
- Implement a generation alongside the index in HandleKey<>.
- Use the generation to check for validity of Entity handles.
- Clean-up unused/misnammed invalid values.
